### PR TITLE
Fix pytest warnings

### DIFF
--- a/backend/app/db/models/alert.py
+++ b/backend/app/db/models/alert.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Optional
 from sqlmodel import Field, SQLModel, Column, Enum, JSON, Relationship, String
 from sqlalchemy.dialects.postgresql import ARRAY, FLOAT
+from pydantic_settings import SettingsConfigDict
 
 from app.schemas.alert import AlertSource, AlertStatus, SeverityLevel
 
@@ -57,5 +58,9 @@ class Alert(SQLModel, table=True):
 
     configuration: Optional[AlertConfiguration] = Relationship(back_populates="events")
 
-    class Config:
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_ignore_empty=True,
+        extra="ignore",
         arbitrary_types_allowed = True
+    )

--- a/backend/app/ml/vector_store.py
+++ b/backend/app/ml/vector_store.py
@@ -5,9 +5,9 @@ Vector Store Module
 from typing import List, Dict, Any, Tuple
 
 from langchain.docstore.document import Document
-from langchain.embeddings import OpenAIEmbeddings
 from langchain.schema import Document
-from langchain.vectorstores import PGVector
+from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores import PGVector
 
 from app.core.config import settings
 


### PR DESCRIPTION
When running pytest, I noticed some warnings, so I set out to fix them. Now pytest runs without warnings:

```
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
rootdir: /workspaces/opslane/backend
configfile: pytest.ini
plugins: anyio-4.4.0, asyncio-0.23.8
asyncio: mode=Mode.AUTO
collected 5 items                                                                                                                                                                  

tests/ml/services/test_prediction.py .....                                                                                                                                   [100%]

================================================================================ 5 passed in 4.86s =================================================================================
```

warning: changes co-authored with help from Unblocked